### PR TITLE
Use abi3 for cross compilation to Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
 
 [[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a35ea0dde58f923bcd30f0f9a64e79033cd51e176c32bd50efccbbe7f289b25"
 dependencies = [
  "once_cell",
+ "python3-dll-a",
  "target-lexicon",
 ]
 
@@ -406,6 +413,15 @@ dependencies = [
  "exr",
  "numpy",
  "pyo3",
+]
+
+[[package]]
+name = "python3-dll-a"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a915bd72824962bf190bbd3e8a044cccb695d1409f73ff5493712eda5136c7a8"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 exr = "1.4.2"
-pyo3 = { version = "0.17", features = ["extension-module"] }
+pyo3 = { version = "0.17", features = ["extension-module", "abi3", "abi3-py310", "generate-abi3-import-lib"] }
 bytemuck = "1.4.1"
 # TODO(dragly-2022-08-26): Bump to next version when reshape issue is fixed: https://github.com/PyO3/rust-numpy/issues/340
 numpy = { git = "https://github.com/dragly/rust-numpy", branch = "dragly-2022-08-26-dims-workaround" }


### PR DESCRIPTION
This makes it possible to cross-compile Windows wheels without
installing an interpreter.

MISC